### PR TITLE
Updated redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To fully use Spooty, you need to create an application in the Spotify Developer 
 2. Sign in with your Spotify account
 3. Create a new application
 4. Note your `Client ID` and `Client Secret`
-5. Configure the redirect URI to `http://localhost:3000/api/callback` (or the corresponding URL of your instance)
+5. Configure the redirect URI to `http://127.0.0.1:3000/api/callback` (or the corresponding URL of your instance)
 
 These credentials will be used by Spooty to access the Spotify API.
 


### PR DESCRIPTION
Changed URI to 127.0.0.1, this used to be localhost as using localhost is not allowed anymore

i know this is like the smallest change ever but spotify did remove the ability to use localhost

https://developer.spotify.com/documentation/web-api/concepts/redirect_uri